### PR TITLE
#28 Update Manifest.MF

### DIFF
--- a/janino-fragment/src/main/resources/META-INF/MANIFEST.MF
+++ b/janino-fragment/src/main/resources/META-INF/MANIFEST.MF
@@ -1,2 +1,3 @@
 Fragment-Host: org.codehaus.janino
-Require-Bundle: ch.qos.logback.core
+DynamicImport-Package: ch.qos.logback.*,\
+org.slf4j


### PR DESCRIPTION
* replaced Require-Bundle with DynamicImport-Package
* to allow janino-fragment see classes in ch.qos.logback.classic  (instead of just ch.qos.logback.core): e.g. ch.qos.logback.classic.Level 
* also added org.slf4j which is also required to be visible and is currently missing
* needed in OSGI environments
* see https://github.com/qos-ch/logback-contrib/issues/28 for details
* this also fixes the change request in https://github.com/qos-ch/logback-contrib/issues/22